### PR TITLE
Add configuration for consumer blacklist

### DIFF
--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -1,5 +1,6 @@
 [general]
 logconfig=/config/logging.cfg
+group-blacklist=GROUP_BLACKLIST
 
 [zookeeper]
 hostname=ZOOKEEPER_HOST

--- a/launch-burrow.sh
+++ b/launch-burrow.sh
@@ -3,6 +3,7 @@ sed -i "s ZOOKEEPER_HOST $ZOOKEEPER_HOST " /config/burrow.cfg
 sed -i "s ZOOKEEPER_PORT $ZOOKEEPER_PORT " /config/burrow.cfg
 sed -i "s KAFKA_HOST $KAFKA_HOST " /config/burrow.cfg
 sed -i "s KAFKA_PORT $KAFKA_PORT " /config/burrow.cfg
+sed -i "s GROUP_BLACKLIST $GROUP_BLACKLIST " /config/burrow.cfg
 
 cat /config/burrow.cfg
 


### PR DESCRIPTION
This is especially for the production publishing cluster, which has as consumers bridges to the lower environments and when these lag consuming messages, the kafka-lagcheck service will start alerting. So, to fix this, will blacklist these consumers.

The ticket is [here](https://trello.com/c/953LWNyU/129-fix-downstream-environments-causing-pub-prod-to-warn-raised-by-bernie-in-techforum-on-27th-april).