### PR TITLE
Adjust the launch script to return the burrow return code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 burrow.out
+.idea/

--- a/launch-burrow.sh
+++ b/launch-burrow.sh
@@ -7,5 +7,3 @@ sed -i "s KAFKA_PORT $KAFKA_PORT " /config/burrow.cfg
 cat /config/burrow.cfg
 
 ./Burrow --config /config/burrow.cfg
-
-cat /burrow.out


### PR DESCRIPTION
- there are several things wrong with burrow
  1. the burrow process doesn't run in PID 1
  2. the logging doesn't work as expected - logs are not being picked up by journalctl
  3. the return code of the app is the return code of the `cat` command, so when burrow fails, fleet doesn't restart it
- this PR fixes only **iii.**
- I tried fixing the logging on the `reconfigure-logging` branch but I can't figure it out yet
- changes are in xp and pub-xp, burrow now restarts on error, which helps the clean startup of clusters
