### PR TITLE
Fix and update image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-FROM alpine:3.4
+FROM golang:1.10-alpine
 
 ADD config/burrow.cfg /config/burrow.cfg
 ADD config/logging.cfg /config/logging.cfg
 ADD launch-burrow.sh /launch-burrow.sh
 
 RUN apk update \
-  && apk add bash \
-  && apk add git bzr \
-  && apk add go \
-  && apk add ca-certificates \
-  && apk add openssl \
+  && apk add git bash\
   && wget https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm && chmod +x gpm \
   && export GOPATH=/gopath \
-  && export BURROW_REPO_PATH="github.com/linkedin/Burrow" \
-  && go get $BURROW_REPO_PATH \
-  && cd $GOPATH/src/${BURROW_REPO_PATH} \
+  && mkdir -p $GOPATH/src/github.com/linkedin/ \
+  && cd $GOPATH/src/github.com/linkedin/ \
+  && git clone https://github.com/linkedin/Burrow.git \
+  && cd Burrow \
   && git checkout v0.1.1 \
-  && /gpm install \
+  && /go/gpm install \
   && go install \
   && mv $GOPATH/bin/Burrow / \
   && apk del go git bzr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update \
   && git checkout v0.1.1 \
   && /go/gpm install \
   && go install \
-  && mv $GOPATH/bin/Burrow / \
+  && mv $GOPATH/bin/Burrow /go \
   && apk del go git bzr \
   && rm -rf $GOPATH /var/cache/apk/* /gpm \
   && touch /burrow.out \

--- a/launch-burrow.sh
+++ b/launch-burrow.sh
@@ -6,5 +6,4 @@ sed -i "s KAFKA_PORT $KAFKA_PORT " /config/burrow.cfg
 
 cat /config/burrow.cfg
 
-pwd
 ./Burrow --config /config/burrow.cfg

--- a/launch-burrow.sh
+++ b/launch-burrow.sh
@@ -6,4 +6,5 @@ sed -i "s KAFKA_PORT $KAFKA_PORT " /config/burrow.cfg
 
 cat /config/burrow.cfg
 
+pwd
 ./Burrow --config /config/burrow.cfg


### PR DESCRIPTION
- the current dockerfile doesn't build anymore, with the error:
```# github.com/DataDog/zstd
In file included from gopath/src/github.com/DataDog/zstd/zstd.go:6:0:
/usr/lib/gcc/x86_64-alpine-linux-musl/6.4.0/include/stdint.h:9:26: error: no include path in which to search for stdint.h
 # include_next <stdint.h>
```
- this error appears when we do a `go get` for burrow, but in the dependencies of burrow, this `DataDog` package doesn't appear, so I replaced the `go get` with `git clone` to avoid this issue
- burrow still builds and works using this method
- upgraded base and removed useless install statements