### PR TITLE
Update cache configuration

### DIFF
--- a/config/burrow.toml
+++ b/config/burrow.toml
@@ -39,3 +39,7 @@ zk-group-refresh=300
 
 [httpserver.default]
 address=":8080"
+
+[evaluator.mystorage]
+class-name="caching"
+expire-cache=20


### PR DESCRIPTION
This might resolve our issue with stale consumer groups due to the MSK migration:
https://github.com/linkedin/Burrow/issues/551